### PR TITLE
Fix two memory access errors

### DIFF
--- a/msdf.h
+++ b/msdf.h
@@ -929,8 +929,9 @@ int msdf_genGlyph(msdf_Result* result, stbtt_fontinfo *font, int stbttGlyphIndex
                 contours[j].end = i;
                 j++;
             }
-
-            contours[j].start = i;
+            if (j < contour_count) {
+                contours[j].start = i;
+            }
         } else if (i >= num_verts) {
             contours[j].end = i;
         }

--- a/msdf.h
+++ b/msdf.h
@@ -1117,8 +1117,8 @@ int msdf_genGlyph(msdf_Result* result, stbtt_fontinfo *font, int stbttGlyphIndex
     // normalize shape
     for (int i = 0; i < contour_count; i++) {
         if (contour_data[i].edge_count == 1) {
-            msdf_EdgeSegment *parts[3] = {0};
-            msdf_edgeSplit(&contour_data[i].edges[0], parts[0], parts[1], parts[2]);
+            msdf_EdgeSegment parts[3] = {0};
+            msdf_edgeSplit(&contour_data[i].edges[0], &parts[0], &parts[1], &parts[2]);
             if (allocCtx.free) {
                 allocCtx.free(contour_data[i].edges, allocCtx.ctx);
             }


### PR DESCRIPTION
I discovered these while testing a broad ASCII range of glyphs (`[!..~]`) from Consolas and Courier New.  Compiling with ASAN identified the out of bounds access at `contours[j].start = i;` after incrementing `j`.  IIRC, the `-` glyph in Consolas entered the conditional block that called `msdf_edgeSplit()` with all `NULL` output locations.  These fixes seem reasonable, the sample output looks correct, and the tested ASCII range completed without any further memory errors.